### PR TITLE
Update maven-shade-plugin to 3.0.0 to fix ManifestResourceTrans…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>2.3</version>
+        <version>3.0.0</version>
         <executions>
           <execution>
             <phase>package</phase>


### PR DESCRIPTION
*Description:*
This PR updates the Maven Shade Plugin from version 2.3 to 3.0.0 to resolve the following build warning:
```
[WARNING] Map in class org.apache.maven.plugins.shade.resource.ManifestResourceTransformer declares value type as: class java.util.jar.Attributes but saw: class java.lang.String at runtime
[WARNING] Map in class org.apache.maven.plugins.shade.resource.ManifestResourceTransformer declares value type as: class java.util.jar.Attributes but saw: class java.lang.String at runtime
```