### PR TITLE
fix: complete handler on deal query failure in local interlock reset

### DIFF
--- a/src/main/java/jp/co/sony/csl/dcoes/apis/main/app/mediator/Interlocking.java
+++ b/src/main/java/jp/co/sony/csl/dcoes/apis/main/app/mediator/Interlocking.java
@@ -372,7 +372,7 @@ public class Interlocking extends AbstractVerticle {
 					completionHandler.handle(Future.succeededFuture());
 				}
 			} else {
-				ErrorExceptionUtil.reportIfNeed(vertx, resDeals.cause());
+				ErrorExceptionUtil.reportIfNeedAndFail(vertx, resDeals.cause(), completionHandler);
 			}
 		});
 	}


### PR DESCRIPTION

## Description
I ran into a deadlock scenario in the error recovery path. 

Basically, if we hit a Local Framework Error (like a network partition) and try to reset the local deal ID, `Interlocking.startResetLocalService_` waits on a `CompositeFuture`. 

## The Issue
In `doResetLocalDealId_`, if the call to `DealUtil.withUnitId()` fails (returns `resDeals.failed()`), the current code handles it like this:

```java
} else {
    // BUG: Logs the error, but never calls completionHandler
    ErrorExceptionUtil.reportIfNeed(vertx, resDeals.cause());
}
```

The problem is that `reportIfNeed` only logs the error—it doesn't touch the `completionHandler`. Since the handler is never completed (neither success nor failure), the parent `CompositeFuture.all()` just waits forever. 

The unit effectively "ghosts" here—it's stuck in a resetting state indefinitely and won't rejoin the grid.

## The Fix
I updated the block to use `reportIfNeedAndFail` instead:

```java
} else {
    // FIX: Logs the error AND fails the future, unblocking the chain
    ErrorExceptionUtil.reportIfNeedAndFail(vertx, resDeals.cause(), completionHandler);
}
```

I checked the sibling method `doResetLocalGridMasterUnitId_` (around line 417), and it was already using this pattern correctly, so I just aligned this method to match.

## Impact
* **Fixes the hang:** We won't get permanently locked out if the deal cache is unreachable during a reset.
* **Better recovery:** The operation will now fail gracefully, allowing the system to retry or escalate instead of failing silently.